### PR TITLE
[fix] update the commands for retrieving container ids

### DIFF
--- a/build/create_secret_ca.sh
+++ b/build/create_secret_ca.sh
@@ -1,6 +1,6 @@
 docker build ./ -t ca_image -f dockerfile_ca
 docker run --name ca -it ca_image:latest
-export CA_CONTAINER_ID=$(docker ps -a --filter name=ca -q)
+export CA_CONTAINER_ID=$(docker ps -a | grep ca_image:latest | awk '{print $1}')
 
 docker cp $CA_CONTAINER_ID:/opt/pki/RootCA/ca_crt.pem secrets/ca_crt.pem
 docker cp $CA_CONTAINER_ID:/opt/pki/RootCA/ca_key.pem secrets/ca_key.pem

--- a/build/create_secret_server.sh
+++ b/build/create_secret_server.sh
@@ -1,6 +1,6 @@
 docker build ./ -t server_image -f dockerfile_server
 docker run --name server -it server_image:latest
-export SERVER_CONTAINER_ID=$(docker ps -a --filter name=server -q)
+export SERVER_CONTAINER_ID=$(docker ps -a | grep server_image:latest | awk '{print $1}')
 
 docker cp $SERVER_CONTAINER_ID:/opt/pki/RootCA/server_crt.pem secrets/server_crt.pem
 docker cp $SERVER_CONTAINER_ID:/opt/pki/RootCA/server_key.pem secrets/server_key.pem


### PR DESCRIPTION
### Resolved issue

#11 

### What I did

Instead of specifying name=ca (or server), the new file returns the container ids whose image is ca_image:latest (or server_image:latest) so that users can retrieve the id of a specific container.